### PR TITLE
Improved deb-helper runner

### DIFF
--- a/deb-jazz
+++ b/deb-jazz
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+runner() {
+  HELPER_VERSION="${VERSION:-2.1.0}"
+  wget -qO- "https://github.com/ConnectedVentures/f8-deb-helper/archive/${HELPER_VERSION}.tar.gz" | tar xvz
+  rm -rf f8-deb-helper
+  mv f8-deb-helper-$HELPER_VERSION f8-deb-helper
+
+  for file in deb_*; do
+    export NAME="${file/deb_/}"
+    ./f8-deb-helper/build-deb
+    ./f8-deb-helper/push-deb
+  done
+}
+
+runner


### PR DESCRIPTION
This change moved the `build-deb` and `push-deb` tasks out of service Makefiles into a script that can be downloaded with `wget` and piped into `bash`. This way there are fewer places in which things can go wrong.

## Usage
Add this to the deployment pipeline:
```sh
wget -qO- https://raw.githubusercontent.com/ConnectedVentures/f8-deb-helper/feature/runner/deb-jazz | VERSION=2.1.0 bash
```
The `VERSION` environment variable refers to the version of f8-deb-helper to download.