### PR TITLE
Updating to use public apt

### DIFF
--- a/push-deb
+++ b/push-deb
@@ -9,7 +9,7 @@ else
   ENV=testing
 fi
 
-APT_REPO="${APT_REPO:-internal.apt.fresh8.tech}"
+APT_REPO="${APT_REPO:-apt.fresh8.tech}"
 ARCH=$(dpkg --print-architecture)
 
 LATEST=$(ls -t1 f8-$NAME*.deb 2>/dev/null | head -n 1)


### PR DESCRIPTION
# Description
i was trying to get debs to build on CircleCI but was getting:
```cp: cannot stat ‘./bin/pipeline’: No such file or directory
cp: cannot stat ‘vendor/src/github.com/connectedventures/f8-pkg/world’: No such file or directory
dpkg-deb: building package `f8-connection-gateway' in `deb_gateway.deb'.
Produced f8-gateway_0.0.0--_amd64.deb
curl: (7) Failed to connect to internal.apt.fresh8.tech port 80: Connection timed out
curl: (7) Failed to connect to internal.apt.fresh8.tech port 80: Connection timed out
curl: (7) Failed to connect to internal.apt.fresh8.tech port 80: Connection timed out
curl: (7) Failed to connect to internal.apt.fresh8.tech port 80: Connection timed out```

So I've updated to use apt.fresh8.tech instead of the internal which will only work for drone.