### PR TITLE
"Build ordered testing" version

### DIFF
--- a/build-deb
+++ b/build-deb
@@ -38,6 +38,11 @@ elif [[ $CI_BRANCH =~ ^release/([0-9]+.[0-9]+.[0-9]+){1}$ ]]; then
   VERSION="${BASH_REMATCH[1]}-b.${CI_BUILD_NUMBER}"
 elif [[ $CI_BRANCH =~ ^release/([0-9]+.[0-9]+){1}$ ]]; then
   VERSION="${BASH_REMATCH[1]}.0-b.${CI_BUILD_NUMBER}"
+elif [[ "$BUILD_ORDERED_TESTING" == true ]]; then
+  # see https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+  # for which character are allowed. "-" is a special case
+  SLUGIFIED_BRANCH=`sed 's/[^0-9A-Za-z+~.]/./g' <<< $CI_BRANCH`
+  VERSION="0.0.${CI_BUILD_NUMBER}+${SLUGIFIED_BRANCH}+${COMMIT_ID}"
 else
   VERSION="0.0.0-${COMMIT_ID}-${CI_BRANCH}"
 fi


### PR DESCRIPTION
This adds an option to use a new version scheme for non-production and non-staging builds.

It will basically let `apt` install the last build when not given a specific version.

Old version scheme has a few shortfalls:
- builds are order alphanumerically by their commit id :new_moon_with_face: 
- version is incorrect due to abuse of the `-` character, but that was never apparent because of previous point.

See it in action [there](https://circleci.com/gh/ConnectedVentures/f8-console/1646)