### PR TITLE
DEB_VERSION, APT_ENV, and no auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # f8-deb-helper
 Helper scripts for DEB deployments
+
+# How to use
+
+`deb-helper` will take care of packaging your files and uploading them to an aptly instance.
+There are 2 main entry-points to achieve this:
+- `build-all-deb`
+- `deb-jazz`, see the Auto-updater section below
+
+
+They both support the same parameters - except `VERSION` as it's `deb-jazz` specific.
+
+### .deb version and aptly environment
+
+`deb-helper` will look at the branch/tag name to construct a gitflow-inspired version number, and decide which of `testing`, `staging` and `production` environment to upload the `.deb` to.
+
+If you wish to bypass this behaviour, you may use:
+- `DEB_VERSION` bash variable to force it to a version of your liking, this will not be validated by `deb-helper`.
+- `APT_ENV` to force the apt environment. This is also not validated in order to give the most freedom (tm).
+
+Example usage of `build-all-deb` with those parameters:
+`APT_ENV=testing DEB_VERSION="5.69.6+very.free.versioning" f8-deb-helper/build-all-deb`
+
+# Auto-updater
+
+`deb-helper` comes with an auto-updater script, this may be used to ease deployment of deb-helper's own bugfixes. In order to use it you will need the following:
+- `python3-pip`
+- `curl`
+- decide which `VERSION` of deb-helper you wish to use
+
+
+You can then invoke the auto-updater and the packager with a one-liner:
+`wget -qO- https://raw.githubusercontent.com/ConnectedVentures/f8-deb-helper/v5.2.0/deb-jazz | VERSION=5.4 bash`

--- a/build-all-deb
+++ b/build-all-deb
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+runner() {
+
+  HELPER_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  for file in deb_*; do
+    export NAME="${file/deb_/}"
+    $HELPER_DIR/build-deb
+    $HELPER_DIR/push-deb
+  done
+}
+
+runner

--- a/build-deb
+++ b/build-deb
@@ -23,7 +23,6 @@ if [[ ! -d $DEB_DIR/DEBIAN ]]; then
   exit 1
 fi
 
-VERSION=unknown
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [[ "$CIRCLECI" == "true" ]]; then
@@ -32,22 +31,26 @@ else
   source $DIR/env_drone
 fi
 
-if [[ $CI_TAG =~ ^v([0-9]+.[0-9]+.[0-9]+)$ ]]; then
-  VERSION=${BASH_REMATCH[1]}
-elif [[ $CI_BRANCH =~ ^release/([0-9]+.[0-9]+.[0-9]+){1}$ ]]; then
-  VERSION="${BASH_REMATCH[1]}-b.${CI_BUILD_NUMBER}"
-elif [[ $CI_BRANCH =~ ^release/([0-9]+.[0-9]+){1}$ ]]; then
-  VERSION="${BASH_REMATCH[1]}.0-b.${CI_BUILD_NUMBER}"
-elif [[ "$BUILD_ORDERED_TESTING" == true ]]; then
-  # see https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
-  # for which character are allowed. "-" is a special case
-  SLUGIFIED_BRANCH=`sed 's/[^0-9A-Za-z+~.]/./g' <<< $CI_BRANCH`
-  VERSION="0.0.${CI_BUILD_NUMBER}+${SLUGIFIED_BRANCH}+${COMMIT_ID}"
-else
-  VERSION="0.0.0-${COMMIT_ID}-${CI_BRANCH}"
-fi
+if [[ -z "$DEB_VERSION" ]]; then
+  if [[ $CI_TAG =~ ^v([0-9]+.[0-9]+.[0-9]+)$ ]]; then
+    VERSION=${BASH_REMATCH[1]}
+  elif [[ $CI_BRANCH =~ ^release/([0-9]+.[0-9]+.[0-9]+){1}$ ]]; then
+    VERSION="${BASH_REMATCH[1]}-b.${CI_BUILD_NUMBER}"
+  elif [[ $CI_BRANCH =~ ^release/([0-9]+.[0-9]+){1}$ ]]; then
+    VERSION="${BASH_REMATCH[1]}.0-b.${CI_BUILD_NUMBER}"
+  elif [[ "$BUILD_ORDERED_TESTING" == true ]]; then
+    # see https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+    # for which character are allowed. "-" is a special case
+    SLUGIFIED_BRANCH=`sed 's/[^0-9A-Za-z+~.]/./g' <<< $CI_BRANCH`
+    VERSION="0.0.${CI_BUILD_NUMBER}+${SLUGIFIED_BRANCH}+${COMMIT_ID}"
+  else
+    VERSION="0.0.0-${COMMIT_ID}-${CI_BRANCH}"
+  fi
 
-VERSION=$(sed "s/\//-/g" <<< $VERSION)
+  VERSION=$(sed "s/\//-/g" <<< $VERSION)
+else
+  VERSION=$DEB_VERSION
+fi
 
 sed -i.bak "s/CI_VERSION/$VERSION/g" $DEB_DIR/DEBIAN/control
 

--- a/push-deb
+++ b/push-deb
@@ -6,13 +6,17 @@ else
   source $DIR/env_drone
 fi
 
-ENV=testing
-if [[ $CI_TAG =~ ^v([0-9]+.[0-9]+.[0-9]+)$ ]]; then
-  ENV=production
-elif [[ $CI_BRANCH =~ ^release/[0-9]+(.[0-9]+){1,2}$ ]]; then
-  ENV=staging
-else
+if [[ -z "$APT_ENV" ]]; then
   ENV=testing
+  if [[ $CI_TAG =~ ^v([0-9]+.[0-9]+.[0-9]+)$ ]]; then
+    ENV=production
+  elif [[ $CI_BRANCH =~ ^release/[0-9]+(.[0-9]+){1,2}$ ]]; then
+    ENV=staging
+  else
+    ENV=testing
+  fi
+else
+  ENV=$APT_ENV
 fi
 
 APT_REPO="${APT_REPO:-internal.apt.fresh8.tech}"


### PR DESCRIPTION
This brings support for a couple of parameters:
- DEB_VERSION: bypass the version decision logic entirely, leaving power to the caller as to what the version should be
- APT_ENV: same thing for the apt repository.

It also comes with a copy of `deb-jazz` not containing the auto-updated logic.

All combined makes the circle ci step look like this:
```
docker:                                                                                                                 
  - image: phusion/baseimage                                                                                            
steps:                                                                                                                  
  - attach_workspace:                                                                                                   
      at: ~/                                                                                                            
  - run: apt-get update                                                                                                 
  - run: apt-get install -y git                                                                                         
  - run: ssh-keyscan apt.fresh8.tech >> ~/.ssh/known_hosts                                                              
  - run: git clone --branch feature/fully-parameterized https://github.com/ConnectedVentures/f8-deb-helper.git          
  - run: APT_ENV=testing DEB_VERSION="0.0.0+testnico+${CIRCLE_BUILD_NUM}.${CIRCLE_SHA1:0:7}" f8-deb-helper/build-all-deb
```

You can see it in action [here](https://circleci.com/workflow-run/872374b7-fb86-4c13-9ef7-b8f1fb9daaba)