### PR TITLE
Add column `:` support in version number

### DIFF
--- a/push-deb
+++ b/push-deb
@@ -36,7 +36,7 @@ if [[ "$DRONE" == "true" ]]; then
   curl -X POST -F "pkg=$(basename $LATEST .deb)" -F "env=$ENV" http://$APT_REPO/notify
 else
   REPO_PATH=/home/apt/.aptly/upload/$LATEST
-  scp $LATEST $CI_USER@$APT_REPO:$REPO_PATH
+  scp ./$LATEST $CI_USER@$APT_REPO:$REPO_PATH
 
   ssh $CI_USER@$APT_REPO 'chmod 0775 '$REPO_PATH'; env='$ENV' deb_filename='$LATEST' aptly-update'
 fi


### PR DESCRIPTION
Classic `scp` problem.

This is required so we can use the `epoch` parameter of [debian versioning](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version) 